### PR TITLE
Update to run ColBERT-X on 3.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /profiler/
 /logs/
 /_publish_model/
+/build/
+/PLAID_X.egg-info
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/colbert/infra/config/core_config.py
+++ b/colbert/infra/config/core_config.py
@@ -7,6 +7,7 @@ from typing import Any
 from collections import defaultdict
 from dataclasses import dataclass, fields
 from colbert.utils.utils import timestamp, torch_load_dnn
+from dataclasses import MISSING
 
 
 @dataclass
@@ -26,7 +27,7 @@ class CoreConfig:
         for field in fields(self):
             field_val = getattr(self, field.name)
 
-            if isinstance(field_val, DefaultVal) or field_val is None:
+            if field.default is not MISSING and hasattr(field.default, 'val'):
                 setattr(self, field.name, field.default.val)
 
             if not isinstance(field_val, DefaultVal):
@@ -34,7 +35,9 @@ class CoreConfig:
     
     def assign_defaults(self):
         for field in fields(self):
-            setattr(self, field.name, field.default.val)
+            
+            if field.default is not MISSING and hasattr(field.default, 'val'):
+                setattr(self, field.name, field.default.val)
             self.assigned[field.name] = True
 
     def configure(self, ignore_unrecognized=True, **kw_args):

--- a/colbert/infra/config/settings.py
+++ b/colbert/infra/config/settings.py
@@ -2,7 +2,7 @@ import os
 import torch
 
 import __main__
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from colbert.utils.utils import timestamp
 
 from .core_config import DefaultVal
@@ -15,25 +15,25 @@ class RunSettings:
         so these aren't soft defaults in that specific context.
     """
 
-    debug: bool = DefaultVal(False)
-    overwrite: bool = DefaultVal(False)
+    debug: bool = field(default_factory=lambda: DefaultVal(False))
+    overwrite: bool = field(default_factory=lambda: DefaultVal(False))
 
-    root: str = DefaultVal(os.path.join(os.getcwd(), 'experiments'))
-    experiment: str = DefaultVal('default')
+    root: str = field(default_factory=lambda: DefaultVal(os.path.join(os.getcwd(), 'experiments')))
+    experiment: str = field(default_factory=lambda: DefaultVal('default'))
 
-    index_root: str = DefaultVal(None)
-    name: str = DefaultVal(timestamp(daydir=True))
+    index_root: str = field(default_factory=lambda: DefaultVal(None))
+    name: str = field(default_factory=lambda: DefaultVal(timestamp(daydir=True)))
 
-    rank: int = DefaultVal(0)
-    nranks: int = DefaultVal(1)
-    amp: bool = DefaultVal(True)
+    rank: int = field(default_factory=lambda: DefaultVal(0))
+    nranks: int = field(default_factory=lambda: DefaultVal(1))
+    amp: bool = field(default_factory=lambda: DefaultVal(True))
 
-    ivf_num_processes: int = DefaultVal(20)
-    ivf_use_tempdir: bool = DefaultVal(False)
-    ivf_merging_ways: int = DefaultVal(2)
+    ivf_num_processes: int = field(default_factory=lambda: DefaultVal(20))
+    ivf_use_tempdir: bool = field(default_factory=lambda: DefaultVal(False))
+    ivf_merging_ways: int = field(default_factory=lambda: DefaultVal(2))
 
     total_visible_gpus = torch.cuda.device_count()
-    gpus: int = DefaultVal(total_visible_gpus)
+    gpus: int = field(default_factory=lambda: DefaultVal(RunSettings.total_visible_gpus))
 
     @property
     def gpus_(self):
@@ -73,7 +73,6 @@ class RunSettings:
                 except:
                     pass
 
-
             assert script_path.endswith('.py')
             script_name = script_path.replace('/', '.').strip('.')[:-3]
 
@@ -98,115 +97,84 @@ class RunSettings:
 
 @dataclass
 class TokenizerSettings:
-    query_token_id: str = DefaultVal("[unused0]")
-    doc_token_id: str = DefaultVal("[unused1]")
-    query_token: str = DefaultVal("[Q]")
-    doc_token: str = DefaultVal("[D]")
+    query_token_id: str = field(default_factory=lambda: DefaultVal("[unused0]"))
+    doc_token_id: str = field(default_factory=lambda: DefaultVal("[unused1]"))
+    query_token: str = field(default_factory=lambda: DefaultVal("[Q]"))
+    doc_token: str = field(default_factory=lambda: DefaultVal("[D]"))
 
 
 @dataclass
 class ResourceSettings:
-    checkpoint: str = DefaultVal(None)
-    triples: str = DefaultVal(None)
-    collection: str = DefaultVal(None)
-    queries: str = DefaultVal(None)
-    index_name: str = DefaultVal(None)
+    checkpoint: str = field(default_factory=lambda: DefaultVal(None))
+    triples: str = field(default_factory=lambda: DefaultVal(None))
+    collection: str = field(default_factory=lambda: DefaultVal(None))
+    queries: str = field(default_factory=lambda: DefaultVal(None))
+    index_name: str = field(default_factory=lambda: DefaultVal(None))
 
 
 @dataclass
 class DocSettings:
-    dim: int = DefaultVal(128)
-    doc_maxlen: int = DefaultVal(220)
-    mask_punctuation: bool = DefaultVal(True)
+    dim: int = field(default_factory=lambda: DefaultVal(128))
+    doc_maxlen: int = field(default_factory=lambda: DefaultVal(220))
+    mask_punctuation: bool = field(default_factory=lambda: DefaultVal(True))
 
 
 @dataclass
 class QuerySettings:
-    query_maxlen: int = DefaultVal(32)
-    attend_to_mask_tokens : bool = DefaultVal(False)
-    interaction: str = DefaultVal('colbert')
+    query_maxlen: int = field(default_factory=lambda: DefaultVal(32))
+    attend_to_mask_tokens: bool = field(default_factory=lambda: DefaultVal(False))
+    interaction: str = field(default_factory=lambda: DefaultVal('colbert'))
 
 
 @dataclass
 class TrainingSettings:
-    similarity: str = DefaultVal('cosine')
+    similarity: str = field(default_factory=lambda: DefaultVal('cosine'))
+    bsize: int = field(default_factory=lambda: DefaultVal(32))
+    accumsteps: int = field(default_factory=lambda: DefaultVal(1))
+    lr: float = field(default_factory=lambda: DefaultVal(3e-06))
+    maxsteps: int = field(default_factory=lambda: DefaultVal(500_000))
+    save_every: int = field(default_factory=lambda: DefaultVal(None))
+    resume: bool = field(default_factory=lambda: DefaultVal(False))
+    resume_optimizer: bool = field(default_factory=lambda: DefaultVal(False))
+    fix_broken_optimizer_state: bool = field(default_factory=lambda: DefaultVal(False))
+    warmup: int = field(default_factory=lambda: DefaultVal(None))
+    warmup_bert: int = field(default_factory=lambda: DefaultVal(None))
+    relu: bool = field(default_factory=lambda: DefaultVal(False))
+    nway: int = field(default_factory=lambda: DefaultVal(2))
+    n_query_alternative: int = field(default_factory=lambda: DefaultVal(1))
+    use_ib_negatives: bool = field(default_factory=lambda: DefaultVal(False))
+    kd_loss: str = field(default_factory=lambda: DefaultVal("KLD"))
+    reranker: bool = field(default_factory=lambda: DefaultVal(False))
+    distillation_alpha: float = field(default_factory=lambda: DefaultVal(1.0))
+    ignore_scores: bool = field(default_factory=lambda: DefaultVal(False))
+    model_name: str = field(default_factory=lambda: DefaultVal("bert-base-uncased"))
+    force_resize_embeddings: bool = field(default_factory=lambda: DefaultVal(True))
+    shuffle_passages: bool = field(default_factory=lambda: DefaultVal(False))
+    sampling_max_beta: float = field(default_factory=lambda: DefaultVal(1.0))
+    over_one_epoch: bool = field(default_factory=lambda: DefaultVal(False))
+    multilang: bool = field(default_factory=lambda: DefaultVal(False))
+    nolangreg: bool = field(default_factory=lambda: DefaultVal(False))
 
-    bsize: int = DefaultVal(32)
-
-    accumsteps: int = DefaultVal(1)
-
-    lr: float = DefaultVal(3e-06)
-
-    maxsteps: int = DefaultVal(500_000)
-
-    save_every: int = DefaultVal(None)
-
-    resume: bool = DefaultVal(False)
-
-    resume_optimizer: bool = DefaultVal(False)
-
-    fix_broken_optimizer_state: bool = DefaultVal(False)
-
-    ## NEW:
-    warmup: int = DefaultVal(None)
-
-    warmup_bert: int = DefaultVal(None)
-
-    relu: bool = DefaultVal(False)
-
-    nway: int = DefaultVal(2)
-
-    n_query_alternative: int = DefaultVal(1)
-
-    use_ib_negatives: bool = DefaultVal(False)
-
-    kd_loss: str = DefaultVal("KLD")
-
-    reranker: bool = DefaultVal(False)
-
-    distillation_alpha: float = DefaultVal(1.0)
-
-    ignore_scores: bool = DefaultVal(False)
-
-    model_name: str = DefaultVal("bert-base-uncased")
-
-    force_resize_embeddings: bool = DefaultVal(True)
-
-    shuffle_passages: bool = DefaultVal(False)
-
-    sampling_max_beta: float = DefaultVal(1.0)
-
-    over_one_epoch: bool = DefaultVal(False)
-
-    multilang: bool = DefaultVal(False)
-
-    nolangreg: bool = DefaultVal(False)
 
 @dataclass
 class IndexingSettings:
-    index_path: str = DefaultVal(None)
-
-    nbits: int = DefaultVal(1)
-
-    kmeans_niters: int = DefaultVal(4)
-
-    resume: bool = DefaultVal(False)
-
-    max_sampled_pid: int = DefaultVal(-1)
-    max_num_partitions: int = DefaultVal(-1)
-
-    use_lagacy_build_ivf: bool = DefaultVal(False)
-
-    reuse_centroids_from: str = DefaultVal(None)
+    index_path: str = field(default_factory=lambda: DefaultVal(None))
+    nbits: int = field(default_factory=lambda: DefaultVal(1))
+    kmeans_niters: int = field(default_factory=lambda: DefaultVal(4))
+    resume: bool = field(default_factory=lambda: DefaultVal(False))
+    max_sampled_pid: int = field(default_factory=lambda: DefaultVal(-1))
+    max_num_partitions: int = field(default_factory=lambda: DefaultVal(-1))
+    use_lagacy_build_ivf: bool = field(default_factory=lambda: DefaultVal(False))
+    reuse_centroids_from: str = field(default_factory=lambda: DefaultVal(None))
 
     @property
     def index_path_(self):
         return self.index_path or os.path.join(self.index_root_, self.index_name)
 
+
 @dataclass
 class SearchSettings:
-    ncells: int = DefaultVal(None)
-    centroid_score_threshold: float = DefaultVal(None)
-    ndocs: int = DefaultVal(None)
-
-    only_approx: bool = DefaultVal(False)
+    ncells: int = field(default_factory=lambda: DefaultVal(None))
+    centroid_score_threshold: float = field(default_factory=lambda: DefaultVal(None))
+    ndocs: int = field(default_factory=lambda: DefaultVal(None))
+    only_approx: bool = field(default_factory=lambda: DefaultVal(False))


### PR DESCRIPTION
@eugene-yang 

This is a fix for ColBERT-X to run on Python 3.12. 
Changes have been tested on a 3.12 environment building from source. 